### PR TITLE
Create SplitView

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gtd_journal/widgets/split_view.dart';
 
 void main() => runApp(const MyApp());
 
@@ -21,15 +22,12 @@ class SplitViewDemo extends StatefulWidget {
 }
 
 class _SplitViewDemoState extends State<SplitViewDemo> {
-  bool isSplit = false;
-  double dividerPosition = 0.5;
-
-  void _handleDragUpdate(DragUpdateDetails details) {
-    setState(() {
-      dividerPosition += details.delta.dx / context.size!.width;
-      dividerPosition = dividerPosition.clamp(0.1, 0.9);
-    });
-  }
+  List<Widget> children = [
+    Container(
+      color: Colors.blue[100],
+      child: const Center(child: Text('View A')),
+    ),
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -37,60 +35,28 @@ class _SplitViewDemoState extends State<SplitViewDemo> {
       appBar: AppBar(
         title: const Text('Arc-style Split View Demo'),
         actions: [
-          ElevatedButton(
+          IconButton(
             onPressed: () {
               setState(() {
-                isSplit = !isSplit;
+                children.add(Container(
+                  color: Colors.purple[100],
+                  child: const Center(child: Text('View D')),
+                ));
               });
             },
-            child: Text(isSplit ? 'Remove Split' : 'Add Right Split'),
+            icon: const Icon(Icons.add),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() {
+                children.removeLast();
+              });
+            },
+            icon: const Icon(Icons.remove),
           ),
         ],
       ),
-      body: isSplit
-          ? Row(
-              children: [
-                Expanded(
-                  flex: (dividerPosition * 100).round(),
-                  child: Container(
-                    color: Colors.blue[100],
-                    child: const Center(child: Text('View A')),
-                  ),
-                ),
-                GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onHorizontalDragUpdate: _handleDragUpdate,
-                  child: CustomPaint(
-                    size: const Size(10, double.infinity),
-                    painter: DividerPainter(),
-                  ),
-                ),
-                Expanded(
-                  flex: ((1 - dividerPosition) * 100).round(),
-                  child: Container(
-                    color: Colors.green[100],
-                    child: const Center(child: Text('View B')),
-                  ),
-                ),
-              ],
-            )
-          : Container(
-              color: Colors.blue[100],
-              child: const Center(child: Text('View A')),
-            ),
+      body: SplitView(children: children),
     );
   }
-}
-
-class DividerPainter extends CustomPainter {
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint = Paint()
-      ..color = Colors.grey
-      ..strokeWidth = 1;
-    canvas.drawLine(Offset(size.width / 2, 0), Offset(size.width / 2, size.height), paint);
-  }
-
-  @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,125 +1,96 @@
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    return const MaterialApp(
+      home: SplitViewDemo(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class SplitViewDemo extends StatefulWidget {
+  const SplitViewDemo({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _SplitViewDemoState createState() => _SplitViewDemoState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _SplitViewDemoState extends State<SplitViewDemo> {
+  bool isSplit = false;
+  double dividerPosition = 0.5;
 
-  void _incrementCounter() {
+  void _handleDragUpdate(DragUpdateDetails details) {
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      dividerPosition += details.delta.dx / context.size!.width;
+      dividerPosition = dividerPosition.clamp(0.1, 0.9);
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: const Text('Arc-style Split View Demo'),
+        actions: [
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                isSplit = !isSplit;
+              });
+            },
+            child: Text(isSplit ? 'Remove Split' : 'Add Right Split'),
+          ),
+        ],
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
+      body: isSplit
+          ? Row(
+              children: [
+                Expanded(
+                  flex: (dividerPosition * 100).round(),
+                  child: Container(
+                    color: Colors.blue[100],
+                    child: const Center(child: Text('View A')),
+                  ),
+                ),
+                GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onHorizontalDragUpdate: _handleDragUpdate,
+                  child: CustomPaint(
+                    size: const Size(10, double.infinity),
+                    painter: DividerPainter(),
+                  ),
+                ),
+                Expanded(
+                  flex: ((1 - dividerPosition) * 100).round(),
+                  child: Container(
+                    color: Colors.green[100],
+                    child: const Center(child: Text('View B')),
+                  ),
+                ),
+              ],
+            )
+          : Container(
+              color: Colors.blue[100],
+              child: const Center(child: Text('View A')),
             ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
+}
+
+class DividerPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.grey
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(size.width / 2, 0), Offset(size.width / 2, size.height), paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }

--- a/lib/widgets/split_view.dart
+++ b/lib/widgets/split_view.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+class SplitView extends StatefulWidget {
+  const SplitView({
+    super.key,
+    required this.children,
+  });
+
+  final List<Widget> children;
+
+  @override
+  State<SplitView> createState() => _SplitViewState();
+}
+
+class _SplitViewState extends State<SplitView> {
+  List<double> dividerPositions = [];
+
+  @override
+  void initState() {
+    super.initState();
+    dividerPositions = List.generate(
+      widget.children.length - 1,
+      (index) => (index + 1) / (widget.children.length + 1),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant SplitView oldWidget) {
+    dividerPositions = List.generate(
+      widget.children.length - 1,
+      (index) => (index + 1) / (widget.children.length + 1),
+    );
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void addSplit() {
+    if (dividerPositions.isEmpty) {
+      dividerPositions.add(0.5);
+    } else {
+      double lastPosition = dividerPositions.last;
+      dividerPositions.add(lastPosition + (1 - lastPosition) / 2);
+    }
+    setState(() {});
+  }
+
+  void removeSplit() {
+    if (dividerPositions.isNotEmpty) {
+      dividerPositions.removeLast();
+      setState(() {});
+    }
+  }
+
+  void _handleDragUpdate(int index, DragUpdateDetails details) {
+    setState(() {
+      dividerPositions[index] += details.delta.dx / context.size!.width;
+      dividerPositions[index] = dividerPositions[index].clamp(
+        index == 0 ? 0.1 : dividerPositions[index - 1] + 0.1,
+        index == dividerPositions.length - 1 ? 0.9 : dividerPositions[index + 1] - 0.1,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scrollbar(
+      scrollbarOrientation: ScrollbarOrientation.bottom,
+      child: Row(
+        children: [
+          for (int i = 0; i <= dividerPositions.length; i++) ...[
+            Expanded(
+              flex: i == 0
+                  ? (dividerPositions.isEmpty ? 100 : (dividerPositions[0] * 100).round())
+                  : i == dividerPositions.length
+                      ? ((1 - dividerPositions.last) * 100).round()
+                      : ((dividerPositions[i] - dividerPositions[i - 1]) * 100).round(),
+              child: widget.children[i],
+            ),
+            if (i < dividerPositions.length)
+              GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onHorizontalDragUpdate: (details) => _handleDragUpdate(i, details),
+                child: CustomPaint(
+                  size: const Size(10, double.infinity),
+                  painter: DividerPainter(),
+                ),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class DividerPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.grey
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(size.width / 2, 0), Offset(size.width / 2, size.height), paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'split_view.dart';


### PR DESCRIPTION
This pull request refactors the main application structure and introduces a new `SplitView` widget to manage a dynamic split view layout. The most important changes include the replacement of the `MyHomePage` widget with `SplitViewDemo`, the creation of the `SplitView` widget, and the addition of export statements for the new widget.

Refactoring and new feature implementation:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R2-R59): Replaced the `MyHomePage` widget with `SplitViewDemo` and updated the main application to use the new `SplitView` widget for a dynamic split view layout.
* [`lib/widgets/split_view.dart`](diffhunk://#diff-3e6a7fc7bd5bc1af2b86d5b1c7a17770ebfbb466c24a1fe43f1f2d984e170574R1-R105): Created a new `SplitView` widget to manage a dynamic split view layout, including functionality to add and remove splits, and handle drag updates for resizing.

Codebase updates:

* [`lib/widgets/widgets.dart`](diffhunk://#diff-af4e17411236a7e6b0ac1a4524ffe3a33be2a7bfe7cf8f7610b4f9078cb0b036R1): Added an export statement for the new `SplitView` widget.