### PR TITLE
DragListView Created

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:gtd_journal/widgets/split_view.dart';
+
+import 'widgets/widgets.dart';
 
 void main() => runApp(const MyApp());
 
@@ -22,26 +23,112 @@ class SplitViewDemo extends StatefulWidget {
 }
 
 class _SplitViewDemoState extends State<SplitViewDemo> {
-  List<Widget> children = [
-    Container(
-      color: Colors.blue[100],
-      child: const Center(child: Text('View A')),
-    ),
-  ];
+  void onAcceptWithDetails(DragTargetAcceptWithDetailsValue details) {
+    final dragListItem = children
+        .expand((element) => element.children)
+        .firstWhere((element) => element.itemId == details.itemId);
+    final fromList = children.firstWhere((fromList) => fromList.id == details.fromListId);
+    final toList = children.firstWhere((toList) => toList.id == details.toListId);
+
+    fromList.children.remove(dragListItem);
+    toList.children.add(dragListItem);
+
+    setState(() {
+      children = [
+        for (final child in children)
+          if (child.id == details.fromListId)
+            child.copyWith(children: fromList.children)
+          else if (child.id == toList.id)
+            child.copyWith(children: toList.children)
+          else
+            child,
+      ];
+    });
+  }
+
+  List<DragListView> children = [];
+
+  @override
+  void initState() {
+    super.initState();
+    children.add(
+      DragListView(
+        id: 1,
+        title: const Text('List 1'),
+        children: [
+          DragListItem(
+            itemId: 1,
+            child: Container(
+              color: Colors.red[100],
+              child: const Center(child: Text('View A')),
+            ),
+          ),
+          DragListItem(
+            itemId: 2,
+            child: Container(
+              color: Colors.green[100],
+              child: const Center(child: Text('View B')),
+            ),
+          ),
+          DragListItem(
+            itemId: 3,
+            child: Container(
+              color: Colors.blue[100],
+              child: const Center(child: Text('View C')),
+            ),
+          ),
+        ],
+        actions: [const Icon(Icons.add), const Icon(Icons.remove)]
+            .map((e) => IconButton(icon: e, onPressed: () {}))
+            .toList(),
+        onAcceptWithDetails: (details) {
+          onAcceptWithDetails(details);
+        },
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Arc-style Split View Demo'),
+        title: const Text('Split View Demo'),
         actions: [
           IconButton(
             onPressed: () {
               setState(() {
-                children.add(Container(
-                  color: Colors.purple[100],
-                  child: const Center(child: Text('View D')),
-                ));
+                children.add(
+                  DragListView(
+                    id: 2,
+                    children: [
+                      DragListItem(
+                        itemId: 4,
+                        child: Container(
+                          color: Colors.red[100],
+                          child: const Center(child: Text('View D')),
+                        ),
+                      ),
+                      DragListItem(
+                        itemId: 5,
+                        child: Container(
+                          color: Colors.green[100],
+                          child: const Center(child: Text('View E')),
+                        ),
+                      ),
+                      DragListItem(
+                        itemId: 6,
+                        child: Container(
+                          color: Colors.blue[100],
+                          child: const Center(child: Text('View F')),
+                        ),
+                      ),
+                    ],
+                    actions: const [Text('hoge')],
+                    onAcceptWithDetails: (details) {
+                      onAcceptWithDetails(details);
+                    },
+                  ),
+                );
               });
             },
             icon: const Icon(Icons.add),

--- a/lib/widgets/drag_list_view.dart
+++ b/lib/widgets/drag_list_view.dart
@@ -1,27 +1,57 @@
 import 'package:flutter/material.dart';
 
+/// A typedef representing the signature of a callback function that is called when a drag target accepts a draggable item with additional details.
+///
+/// The [fromListId] parameter represents the ID of the list from which the item is being dragged.
+/// The [toListId] parameter represents the ID of the list to which the item is being dragged.
+/// The [itemId] parameter represents the ID of the item being dragged.
+typedef DragTargetAcceptWithDetailsValue = ({
+  int? fromListId,
+  int? toListId,
+  int itemId,
+});
+
 class DragListItem {
   const DragListItem({
-    required this.id,
+    this.listId,
+    required this.itemId,
     this.draggingChild,
     required this.child,
   });
 
+  /// The unique identifier for the drag list
+  final int? listId;
+
   /// The unique identifier for the drag list item
-  final int id;
+  final int itemId;
 
   /// The widget to display when the item is being dragged
   final Widget? draggingChild;
 
   /// The main widget to display for the item
   final Widget child;
+
+  DragListItem copyWith({
+    int? listId,
+    int? itemId,
+    Widget? draggingChild,
+    Widget? child,
+  }) {
+    return DragListItem(
+      listId: listId ?? this.listId,
+      itemId: itemId ?? this.itemId,
+      draggingChild: draggingChild ?? this.draggingChild,
+      child: child ?? this.child,
+    );
+  }
 }
 
 /// A widget that displays a list of draggable items.
 class DragListView extends StatelessWidget {
-  const DragListView({
+  DragListView({
     super.key,
-    required this.children,
+    this.id,
+    required List<DragListItem> items,
     this.feedback = const SizedBox.square(
       dimension: 100,
       child: ColoredBox(
@@ -34,7 +64,10 @@ class DragListView extends StatelessWidget {
     ),
     this.draggingChild,
     required this.onAcceptWithDetails,
-  });
+  }) : children = items.map((e) => e.copyWith(listId: id)).toList();
+
+  /// The unique identifier for the drag list
+  final int? id;
 
   /// The list of draggable items to display.
   final List<DragListItem> children;
@@ -46,11 +79,11 @@ class DragListView extends StatelessWidget {
   final Widget? draggingChild;
 
   /// Callback function that is called when an item is accepted by a [DragTarget].
-  final DragTargetAcceptWithDetails<int> onAcceptWithDetails;
+  final void Function(DragTargetAcceptWithDetailsValue) onAcceptWithDetails;
 
   @override
   Widget build(BuildContext context) {
-    return DragTarget<int>(
+    return DragTarget<DragListItem>(
       builder: (
         BuildContext context,
         List<dynamic> accepted,
@@ -59,8 +92,8 @@ class DragListView extends StatelessWidget {
         return ListView.builder(
           itemCount: children.length,
           itemBuilder: (context, index) {
-            return Draggable<int>(
-              data: children[index].id,
+            return Draggable<DragListItem>(
+              data: children[index],
               feedback: feedback,
               childWhenDragging: children[index].draggingChild ??
                   draggingChild ??
@@ -73,7 +106,34 @@ class DragListView extends StatelessWidget {
           },
         );
       },
-      onAcceptWithDetails: onAcceptWithDetails,
+      onAcceptWithDetails: (details) {
+        // If the item is being dragged to the same list, do nothing
+        if (details.data.listId == id) {
+          return;
+        }
+
+        onAcceptWithDetails((
+          fromListId: details.data.listId,
+          toListId: id,
+          itemId: details.data.itemId,
+        ));
+      },
+    );
+  }
+
+  DragListView copyWith({
+    int? id,
+    List<DragListItem>? children,
+    Widget? feedback,
+    Widget? draggingChild,
+    void Function(DragTargetAcceptWithDetailsValue)? onAcceptWithDetails,
+  }) {
+    return DragListView(
+      id: id ?? this.id,
+      items: children ?? this.children,
+      feedback: feedback ?? this.feedback,
+      draggingChild: draggingChild ?? this.draggingChild,
+      onAcceptWithDetails: onAcceptWithDetails ?? this.onAcceptWithDetails,
     );
   }
 }

--- a/lib/widgets/drag_list_view.dart
+++ b/lib/widgets/drag_list_view.dart
@@ -51,6 +51,9 @@ class DragListView extends StatefulWidget {
     super.key,
     this.id,
     required this.children,
+    this.leading,
+    this.title,
+    this.actions = const <Widget>[],
     this.draggingChild,
     required this.onAcceptWithDetails,
   });
@@ -60,6 +63,15 @@ class DragListView extends StatefulWidget {
 
   /// The list of draggable items to display.
   final List<DragListItem> children;
+
+  /// The leading widget to display at the top of the list.
+  final Widget? leading;
+
+  /// The title to display at the top of the list.
+  final Widget? title;
+
+  /// The list of actions to display at the top of the list.
+  final List<Widget> actions;
 
   /// The widget to display as the dragged item.
   final Widget? draggingChild;
@@ -109,6 +121,28 @@ class _DragListViewState extends State<DragListView> {
         List<dynamic> rejected,
       ) {
         return ReorderableListView(
+          header: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: widget.leading != null || widget.title != null || widget.actions.isNotEmpty
+                ? [
+                    Row(
+                      children: [
+                        if (widget.leading != null) widget.leading!,
+                        if (widget.title != null) widget.title!,
+                        const Spacer(),
+                        for (var index = 0; index < widget.actions.length; index++)
+                          Padding(
+                            padding: index == widget.actions.length - 1
+                                ? const EdgeInsets.only(right: 16.0)
+                                : const EdgeInsets.only(right: 24.0),
+                            child: widget.actions[index],
+                          ),
+                      ],
+                    ),
+                    const Divider(),
+                  ]
+                : const <Widget>[],
+          ),
           onReorder: (oldIndex, newIndex) {
             if (oldIndex < newIndex) {
               newIndex -= 1;

--- a/lib/widgets/drag_list_view.dart
+++ b/lib/widgets/drag_list_view.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+class DragListItem {
+  const DragListItem({
+    required this.id,
+    this.draggingChild,
+    required this.child,
+  });
+
+  /// The unique identifier for the drag list item
+  final int id;
+
+  /// The widget to display when the item is being dragged
+  final Widget? draggingChild;
+
+  /// The main widget to display for the item
+  final Widget child;
+}
+
+/// A widget that displays a list of draggable items.
+class DragListView extends StatelessWidget {
+  const DragListView({
+    super.key,
+    required this.children,
+    this.feedback = const SizedBox.square(
+      dimension: 100,
+      child: ColoredBox(
+        color: Colors.redAccent,
+        child: Icon(
+          Icons.directions_run,
+          size: 40.0,
+        ),
+      ),
+    ),
+    this.draggingChild,
+    required this.onAcceptWithDetails,
+  });
+
+  /// The list of draggable items to display.
+  final List<DragListItem> children;
+
+  /// The widget to display as feedback when an item is being dragged.
+  final Widget feedback;
+
+  /// The widget to display as the dragged item.
+  final Widget? draggingChild;
+
+  /// Callback function that is called when an item is accepted by a [DragTarget].
+  final DragTargetAcceptWithDetails<int> onAcceptWithDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    return DragTarget<int>(
+      builder: (
+        BuildContext context,
+        List<dynamic> accepted,
+        List<dynamic> rejected,
+      ) {
+        return ListView.builder(
+          itemCount: children.length,
+          itemBuilder: (context, index) {
+            return Draggable<int>(
+              data: children[index].id,
+              feedback: feedback,
+              childWhenDragging: children[index].draggingChild ??
+                  draggingChild ??
+                  Opacity(
+                    opacity: 0.5,
+                    child: children[index].child,
+                  ),
+              child: children[index].child,
+            );
+          },
+        );
+      },
+      onAcceptWithDetails: onAcceptWithDetails,
+    );
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,1 +1,2 @@
+export 'drag_list_view.dart';
 export 'split_view.dart';


### PR DESCRIPTION
This pull request introduces a new drag-and-drop feature for list items in the Flutter application. The most important changes include adding a new `DragListView` widget, updating the `SplitViewDemo` class to utilize this new widget, and refactoring the import statements to accommodate the new structure.

### Drag-and-Drop Feature Implementation:

* [`lib/widgets/drag_list_view.dart`](diffhunk://#diff-8bb5638ffdd5344903374370224aba8155dec687762d5a94bdb2c7986f99d6a9R1-R185): Added a new `DragListView` widget with support for drag-and-drop functionality, including a `DragTargetAcceptWithDetailsValue` typedef and `DragListItem` class. This widget allows items to be dragged between lists and handles the reordering of items within a list.

### Application Updates:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L25-R131): Updated the `SplitViewDemo` class to use the new `DragListView` widget. This includes initializing lists with draggable items and handling the acceptance of dragged items.

### Code Refactoring:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L2-R3): Refactored import statements to use a consolidated `widgets.dart` file.
* [`lib/widgets/widgets.dart`](diffhunk://#diff-af4e17411236a7e6b0ac1a4524ffe3a33be2a7bfe7cf8f7610b4f9078cb0b036R1): Exported the new `drag_list_view.dart` file to make the `DragListView` widget available throughout the application.